### PR TITLE
Fix scipy, scikit-learn and pytest versions to be py3.10 compatible

### DIFF
--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.10.0
   - pip=23.3.1
   - requests=2.24.0
-  - scikit-learn=1.3.2
+  - scikit-learn=1.5.2
   - pip:
       - mlflow==2.8.1
       - wandb==0.16.0

--- a/src/data_check/conda.yml
+++ b/src/data_check/conda.yml
@@ -5,8 +5,8 @@ channels:
 dependencies:
   - python=3.10.0
   - pandas=2.1.3
-  - pytest=6.2.2
-  - scipy=1.5.2
+  - pytest=7.4.4
+  - scipy=1.13.1
   - pip=23.3.1
   - pip:
       - mlflow==2.8.1

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -8,7 +8,7 @@ dependencies:
   - matplotlib=3.8.2
   - pandas=2.1.3
   - pip=23.3.1
-  - scikit-learn=1.3.2
+  - scikit-learn=1.5.2
   - pip:
       - mlflow==2.8.1
       - wandb==0.16.0


### PR DESCRIPTION
These changes are required due to recent changes in Python 3.10 that no longer honour the dependencies originally set out by these particular conda environments in the `data_check` and `train_random_forest` step. In particular, `scipy=1.5.2` is now being restricted to Python 3.6 and 3.7. As this project uses Python 3.10, `scipy` now needs to be upgraded. Because of this upgrade, `pytest` will also need to be upgraded. Finally, `scikit-learn` in the `train_random_forest` step has been upgraded to version 1.5.2 to ensure uniformity. Every other conda.yml file that uses `scikit-learn` is specified to have 1.5.2. 

Using these dependencies as is from the original repo will now generate the following unresolved dependency errors in the `data_check` step - these are snapshots provided by another student:

![a5171114-e9d0-4dd4-b8f9-359afb30a565-mobile](https://github.com/user-attachments/assets/d5a15e87-063b-4980-92e4-a699badc299a)

![59eeb103-84f8-42ed-afe8-b8a3340a1769-mobile](https://github.com/user-attachments/assets/084fc954-f5cb-4f90-8f1b-d005012d7c16)

