### PR TITLE
Infer signature fix - no longer needed

### DIFF
--- a/src/eda/conda.yml
+++ b/src/eda/conda.yml
@@ -8,7 +8,7 @@ dependencies:
   - matplotlib=3.8.2
   - pandas=2.1.3
   - pip=23.3.1
-  - scikit-learn=1.3.2
+  - scikit-learn=1.5.2
   - jupyterlab=4.1.3
   - pip:
       - mlflow==2.8.1

--- a/src/train_random_forest/run.py
+++ b/src/train_random_forest/run.py
@@ -17,7 +17,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import OrdinalEncoder, FunctionTransformer
+from sklearn.preprocessing import OrdinalEncoder, FunctionTransformer, OneHotEncoder
 
 import wandb
 from sklearn.ensemble import RandomForestRegressor
@@ -95,10 +95,8 @@ def go(args):
     ######################################
     # Save the sk_pipe pipeline as a mlflow.sklearn model in the directory "random_forest_dir"
     # HINT: use mlflow.sklearn.save_model
-    signature = mlflow.models.infer_signature(X_val, y_pred)
     mlflow.sklearn.save_model(
         # YOUR CODE HERE
-        signature = signature,
         input_example = X_train.iloc[:5]
     )
     ######################################


### PR DESCRIPTION
Due to the recent updates to the scikit-learn and scipy packages in this pull request (https://github.com/udacity/Project-Build-an-ML-Pipeline-Starter/pull/22), the `infer_signature` method found in `src/train_random_forest/run.py` is no longer required and does not need to be used in the `mlflow.sklearn.save_model` method. Leaving this alone will generate the following error (provided by a student):

![59624797-009a-46ae-b37b-b409b4708dda-mobile](https://github.com/user-attachments/assets/f0f2c055-1e3d-4131-8526-2f609bd4db74)

As such, this PR removes the `infer_signature` call to remove this error - it is no longer needed. This PR also updates one conda.yml file so that the scikit-learn version is set to 1.5.2, like all other conda.yml files in this repository. Finally, in the `src/train_random_forest/run.py` file, a hint refers to using the `OneHotEncoder` class, but it is not imported as part of import statements. Questions were also asked in this regard, so to make things slightly easier, this import statement was completed to be preemptive.