### PR TITLE
Upgrade wandb to 0.24.0

### DIFF
--- a/components/get_data/conda.yml
+++ b/components/get_data/conda.yml
@@ -9,5 +9,5 @@ dependencies:
   - pyarrow=21.0.0
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0
       - -e ..

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -11,5 +11,5 @@ dependencies:
   - numpy=2.1.0
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0
       - -e ..

--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -9,5 +9,5 @@ dependencies:
   - scikit-learn=1.7.2
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0
       - -e ..

--- a/conda.yml
+++ b/conda.yml
@@ -9,4 +9,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0

--- a/src/basic_cleaning/conda.yml
+++ b/src/basic_cleaning/conda.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip=24.3.1
   - pandas=2.3.2
   - pip:
-      - wandb==0.22.0
+      - wandb==0.24.0
 

--- a/src/data_check/conda.yml
+++ b/src/data_check/conda.yml
@@ -10,4 +10,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0

--- a/src/eda/conda.yml
+++ b/src/eda/conda.yml
@@ -11,4 +11,4 @@ dependencies:
   - jupyterlab=4.4.7
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -12,4 +12,4 @@ dependencies:
   - numpy=2.1.0
   - pip:
       - mlflow==3.3.2
-      - wandb==0.22.0
+      - wandb==0.24.0


### PR DESCRIPTION
wandb has recently changed the way it generates API keys, and as a result, these are incompatible with older versions of wandb. We are now required to use at least version 0.24.0 to handle the new API key format. This PR changes all affected conda YAML files to respect this new version.